### PR TITLE
allow missing values for forward pass

### DIFF
--- a/examples/1_pc_training/train_mnist_hclt.py
+++ b/examples/1_pc_training/train_mnist_hclt.py
@@ -179,7 +179,7 @@ def main(args):
 
     elif args.mode == "miss":
         print("===========================MISS===============================")    
-        print(f"Loading {filename} into {device}.......", end="")
+        print(f"Loading {filename} into {device}.......")
         pc = torch.load(filename)
         pc.to(device)
     
@@ -193,17 +193,25 @@ def main(args):
             shuffle = False,
             drop_last = True
         )
-        train_ll = evaluate(pc, loader=train_loader)
+        t_compile = time.time()
         test_ll = evaluate(pc, loader=test_loader) 
         test_ll_miss = evaluate_miss(pc, loader=test_loader_miss) 
+
+        t0 = time.time()
+        train_ll = evaluate(pc, loader=train_loader)
+        t1 = time.time()
+        test_ll = evaluate(pc, loader=test_loader) 
+        t2 = time.time()
+        test_ll_miss = evaluate_miss(pc, loader=test_loader_miss) 
+        t3 = time.time()
 
         train_bpd = -train_ll / (num_features * np.log(2))
         test_bpd = -test_ll / (num_features * np.log(2))
         test_miss_bpd = -test_ll_miss / (num_features * np.log(2))
 
-        print(f"train_ll: {train_ll:.2f}, train_bpd: {train_bpd:.2f}")
-        print(f"test_ll: {test_ll:.2f}, test_bpd: {test_bpd:.2f}")
-        print(f"test_miss_ll: {test_ll_miss:.2f}, test_miss_bpd: {test_miss_bpd:.2f}")
+        print(f"train_ll: {train_ll:.2f}, train_bpd: {train_bpd:.2f}; time = {t1-t0:.2f} (s)")
+        print(f"test_ll: {test_ll:.2f}, test_bpd: {test_bpd:.2f}; time = {t2-t1:.2f} (s)")
+        print(f"test_miss_ll: {test_ll_miss:.2f}, test_miss_bpd: {test_miss_bpd:.2f}; time = {t3-t2:.2f} (s)")
 
     print(f"Memory allocated: {torch.cuda.memory_allocated(device) / 1024 / 1024 / 1024:.1f}GB")
     print(f"Memory reserved: {torch.cuda.memory_reserved(device) / 1024 / 1024 / 1024:.1f}GB")

--- a/src/pyjuice/layer/input_layers/categorical_layer.py
+++ b/src/pyjuice/layer/input_layers/categorical_layer.py
@@ -144,10 +144,11 @@ class CategoricalLayer(InputLayer):
         sid, eid = self._output_ind_range[0], self._output_ind_range[1]
         param_idxs = data[self.vids] + self.psids.unsqueeze(1)
         if missing_mask is not None:
-            not_missing_mask = ~missing_mask[self.vids]
-            node_mars[sid:eid,:][not_missing_mask] = ((params[param_idxs][not_missing_mask]).clamp(min=1e-10)).log()
+            mask = missing_mask[self.vids]
+            node_mars[sid:eid,:][~mask] = ((params[param_idxs][~mask]).clamp(min=1e-10)).log()
+            node_mars[sid:eid,:][mask] = 0.0
         else:
-            node_mars[sid:eid,:] = ((params[param_idxs]).clamp(min=1e-10)).log()
+            node_mars[sid:eid,:] = ((params[param_idxs]).clamp(min=1e-10)).log()            
         return None
 
     @torch.compile(mode = "reduce-overhead")


### PR DESCRIPTION
Tested with
```
python examples/1_pc_training/train_mnist_hclt.py --output_dir=examples/circuits/ --mode=miss
```

