### PR TITLE
Conditional Sample from circuits

### DIFF
--- a/examples/1_pc_training/train_mnist_hclt.py
+++ b/examples/1_pc_training/train_mnist_hclt.py
@@ -248,7 +248,25 @@ def main(args):
         print(f"train_ll: {train_ll:.2f}, test_ll: {test_ll:.2f}")
         print(f"train_ll_alpha: {train_ll_alpha:.2f}, test_ll_alpha: {test_ll_alpha:.2f}")
         print(f"train {t1-t0:.2f} (s); test {t2-t1:.2f} (s)")
-    
+
+    elif args.mode == "sample":
+        print("===========================SAMPLE===============================")
+        pc = load_circuit(filename, verbose=True, device=device)
+        pc.to(device)
+
+        for batch in train_loader:
+            x = batch[0].to(device)
+            miss_mask = torch.zeros(x.size(), dtype=torch.bool, device=device)
+            miss_mask[:, 1:100] = 1 
+
+            # 1. Run Forward Pass
+            lls = pc(x, missing_mask=miss_mask)
+            print(lls.mean().squeeze().detach().item())
+            # 2. Sample with backward
+            samples = pc.sample(x, miss_mask)
+
+            print(samples.size())
+            break # only want to sample from first batch
 
     print(f"Memory allocated: {torch.cuda.memory_allocated(device) / 1024 / 1024 / 1024:.1f}GB")
     print(f"Memory reserved: {torch.cuda.memory_reserved(device) / 1024 / 1024 / 1024:.1f}GB")

--- a/examples/1_pc_training/train_mnist_hclt.py
+++ b/examples/1_pc_training/train_mnist_hclt.py
@@ -255,25 +255,33 @@ def main(args):
 
     elif args.mode == "sample":
         print("===========================SAMPLE===============================")
+        device="cpu"
         pc = load_circuit(filename, verbose=True, device=device)
         pc.to(device)
+
+        train_loader = DataLoader(
+            dataset = TensorDataset(train_data),
+            batch_size = 4,
+            shuffle = False,
+            drop_last = False
+        )
 
         for batch in train_loader:
             x = batch[0].to(device)
             miss_mask = torch.zeros(x.size(), dtype=torch.bool, device=device)
-            miss_mask[:, 0:100] = 1 
-
+            miss_mask[:, 0:14*28] = 1 
             # 1. Run Forward Pass
             lls = pc(x, missing_mask=miss_mask)
             print(lls.mean().squeeze().detach().item())
             # 2. Sample with backward
             samples = pc.sample(x, miss_mask)
 
-            # Plot first 8 Samples
+            # Plot first 4 Samples
+            print("Saving Samples as images to file")
             plt.figure()
-            f, axarr = plt.subplots(3, 8, figsize=(28, 10))
+            f, axarr = plt.subplots(3, 4, figsize=(28, 10))
             plt.gray()
-            for i in range(8):
+            for i in range(4):
                 axarr[0][i].imshow(x[i, :].reshape(28,28).cpu().numpy().astype(np.uint8))
                 axarr[1][i].imshow(255*miss_mask[i, :].reshape(28,28).cpu().numpy().astype(np.uint8))
                 axarr[2][i].imshow(samples[i, :].reshape(28,28).cpu().numpy().astype(np.uint8))

--- a/src/pyjuice/layer/input_layers/categorical_layer.py
+++ b/src/pyjuice/layer/input_layers/categorical_layer.py
@@ -144,12 +144,12 @@ class CategoricalLayer(InputLayer):
          - node_flows[sid:eid].size() == (num_input_nodes, B)
         """
         sid, eid = self._output_ind_range[0], self._output_ind_range[1]
-        print(f"Input layer w/+ flows (should be {samples.size(1)})", node_flows[sid:eid, :].sum(dim=0))   
+        # print(f"Input layer w/+ flows (should be {samples.size(0)})", node_flows[sid:eid, :].sum(dim=0))   
     
         node_idxs, batch_idxs = node_flows[sid:eid, :].nonzero(as_tuple=True)   # (num_vars * B, 2)
         var_idxs = self.vids[node_idxs]                                         # (num_vars * B) 
         
-        sampled_node_idxs = torch.zeros(samples.shape, dtype=torch.long)#.cuda() TODO uncomment .cuda
+        sampled_node_idxs = torch.zeros(samples.shape, dtype=torch.long, device=samples.device)
         sampled_node_idxs[var_idxs, batch_idxs] = node_idxs
 
         # TODO fix later, for now assume constant number of cats 
@@ -157,7 +157,7 @@ class CategoricalLayer(InputLayer):
         ps = self.params.view(-1, self.psids[1])                        # (num_nodes, num_cats)
         cummulp = ps.cumsum(-1)
         replace_cummul_ps = cummulp[sampled_node_idxs]                 # (var, B, num_cats)
-        rands = torch.rand(samples.size(0), samples.size(1), 1)#.cuda() TODO uncomment .cuda # (vars, B, 1)
+        rands = torch.rand(samples.size(0), samples.size(1), 1, device=samples.device)  # (vars, B, 1)
     
         sampled_cats = torch.sum(rands > replace_cummul_ps, dim=2).to(samples.dtype)
         samples[missing_mask] = sampled_cats[missing_mask]

--- a/src/pyjuice/layer/input_layers/categorical_layer.py
+++ b/src/pyjuice/layer/input_layers/categorical_layer.py
@@ -132,6 +132,12 @@ class CategoricalLayer(InputLayer):
         self._flows_kernel[grid](self.param_flows, node_flows, param_ids, layer_num_nodes, tot_num_nodes, batch_size, node_offset, BLOCK_SIZE = 1024)
         
         return None
+    
+    def sample(self, samples: torch.Tensor, missing_mask:torch.tensor, node_flows: torch.tensor):
+        # sample and replace only the missing values (input nodes should have either flow 0 or 1, 1 mean being active and should sample using that input node)
+        # only sample when missing_mask is True for that feature and input.
+        pass
+
 
     def mini_batch_em(self, step_size: float, pseudocount: float = 0.0):
         if not self._used_external_params:

--- a/src/pyjuice/layer/sum_layer.py
+++ b/src/pyjuice/layer/sum_layer.py
@@ -225,7 +225,7 @@ class SumLayer(Layer,nn.Module):
         else:
             self._dense_forward_pass(node_mars, element_mars, params)
 
-    # @torch.compile(mode = "reduce-overhead", fullgraph = True)
+    @torch.compile(mode = "reduce-overhead", fullgraph = True)
     def sample(self, node_flows: torch.Tensor, 
                         element_flows: torch.Tensor, 
                         node_mars: torch.Tensor, 
@@ -243,7 +243,7 @@ class SumLayer(Layer,nn.Module):
 
         for group_id in range(self.num_backward_groups):
             nids = self.grouped_nids[group_id]
-            cids = self.grouped_cids[group_id]
+            cids = self.grouped_cids[group_id]   # (num_sum_nodes, max_sum_children)
             pids = self.grouped_pids[group_id]
 
             chids = self.grouped_chids[group_id]
@@ -253,9 +253,13 @@ class SumLayer(Layer,nn.Module):
             #       flow_c* = flow_n
             #       flow_c =  0 for every other c != c*
             probs = params[pids] * element_mars[cids].exp()                                      # (num_sum_nodes, max_sum_children, batch_size)
-            cummul_probs = torch.cumsum(probs[:, 0:-1, :], -2)                                   # (num_sum_nodes, max_sum_children, batch_size)
-            rand = cummul_probs[:,-1:,:] * torch.rand((probs.size(0), 1, probs.size(2))).cuda()  # (num_sum_nodes, 1, batch_size)
-            sampled_idx = torch.sum(rand > cummul_probs, -2).long()                              # (num_sum_nodes, batch_size)            
+            cummul_probs = torch.cumsum(probs[:, :, :], 1)                                       # (num_sum_nodes, max_sum_children, batch_size)
+            cummul_probs = cummul_probs[:, -1:, :]                                               # (num_sum_nodes, 1, batch_size)
+            
+            rand = torch.rand((probs.size(0), 1, probs.size(2))).cuda()                          # (num_sum_nodes, 1, batch_size)
+            rand = cummul_probs * rand                                                           # (num_sum_nodes, 1, batch_size)   
+
+            sampled_idx = torch.sum(rand > cummul_probs, dim=1).long()                           # (num_sum_nodes, batch_size)             
             sampled_child_ids = torch.gather(cids, 1, sampled_idx)                               # (num_sum_nodes, batch_size)
             element_flows[chids] = torch.scatter_add(element_flows[chids], dim=0, index=sampled_child_ids, src=node_flows[nids])
 

--- a/src/pyjuice/layer/sum_layer.py
+++ b/src/pyjuice/layer/sum_layer.py
@@ -233,7 +233,6 @@ class SumLayer(Layer,nn.Module):
         else:
             self._dense_forward_pass(node_mars, element_mars, params)
 
-    # @torch.compile(mode = "reduce-overhead", fullgraph = True)
     def sample(self, node_flows: torch.Tensor, 
                element_flows: torch.Tensor, 
                node_mars: torch.Tensor, 
@@ -402,7 +401,7 @@ class SumLayer(Layer,nn.Module):
 
         return None
 
-    # @torch.compile(mode = "reduce-overhead", fullgraph = True)
+    @torch.compile(mode = "reduce-overhead", fullgraph = True)
     def _sample_backward_pass(self, node_flows: torch.Tensor, element_flows: torch.Tensor, node_mars: torch.Tensor, 
                               element_mars: torch.Tensor, params: torch.Tensor, node_mask: torch.Tensor):
         for group_id in range(self.num_backward_groups):

--- a/src/pyjuice/layer/sum_layer.py
+++ b/src/pyjuice/layer/sum_layer.py
@@ -254,12 +254,28 @@ class SumLayer(Layer,nn.Module):
             #      that child c* will have all the flow 
             #       flow_c* = 1 * flow_n
             #       flow_c = 0 * flow_n for every other c
-            probs = params[pids] * element_mars[cids].exp()           # (num_sum_nodes, max_sum_children)
-            rand = torch.rand((nids.shape[0], 1), device=self.device) # (num_sum_nodes) 
-            cummul_probs = torch.cumsum(probs[:, 0:-1], -1)
-            sampled_idx = torch.sum(rand > cummul_probs, -1).long()   # (num_sum_nodes)
+            probs = params[pids] * element_mars[cids].exp()                    # (num_sum_nodes, max_sum_children, batch_size)
+            cummul_probs = torch.cumsum(probs[:, 0:-1], -1)                    # (num_sum_nodes, max_sum_children, batch_size)
+            rand = torch.rand((nids.shape[0], 1, probs.size(2))).cuda()#, device=self.device) # (num_sum_nodes, 1, batch_size)
 
-            # element_flows[chids] += node_flows[nids] * sampled_flows[parpids] 
+            print("probs", probs.shape)
+            print("rand", rand.shape)
+            print("cummul_probs", cummul_probs.shape)
+            
+            sampled_idx = torch.sum(rand > cummul_probs, -2).long()   # (num_sum_nodes, batch_size)
+            
+            print("nids", nids.shape)
+            print("cids", cids.shape)
+            print("chids", chids.shape)
+            print("sampled_idx", sampled_idx.shape)
+            print("element_flows[chids]", element_flows[chids].shape)
+            print("node_flows[nids]",  node_flows[nids].shape)
+            # print("nids[sampled_idx]", nids[sampled_idx].shape)
+            # chids torch.Size([1440])
+            # sampled_idx torch.Size([1440, 512])            
+
+            # element_flows[chids] += node_flows[nids]
+            print('--------------------')
 
 
     def backward(self, node_flows: torch.Tensor, 

--- a/src/pyjuice/layer/sum_layer.py
+++ b/src/pyjuice/layer/sum_layer.py
@@ -247,7 +247,7 @@ class SumLayer(Layer,nn.Module):
             pids = self.grouped_pids[group_id]
 
             chids = self.grouped_chids[group_id]
-    
+
             # For each sum node `n` we need to sample a child proportional to theta_{c|n} * pr_c
             # That child c* will have all the flow_c (and flow_c was either 0 or 1), i.e:
             #       flow_c* = flow_n

--- a/src/pyjuice/model/probcircuit.py
+++ b/src/pyjuice/model/probcircuit.py
@@ -285,7 +285,7 @@ class ProbCircuit(nn.Module):
                 
 
             for idx, layer in enumerate(self.input_layers):
-                layer.sample(samples, missing_mask, self.node_flows, self.element_flows, self.node_mars, self.element_mars)
+                layer.sample(samples, missing_mask, self.node_flows)
 
         return samples.permutes(1, 0)
         

--- a/src/pyjuice/model/probcircuit.py
+++ b/src/pyjuice/model/probcircuit.py
@@ -241,6 +241,55 @@ class ProbCircuit(nn.Module):
                 self._used_external_sum_params = False
 
         return None
+    
+    def sample(self, inputs: torch.Tensor, missing_mask: torch.Tensor):
+        """
+        conditional samples from pr(x_missing | x_not missing) for each input in the batch
+
+        Arguments:
+         - inputs:             tensor       (num_features, batch_size)
+         - missing_mask:       tensor[bool] (num_features, batch_size)
+
+        Requirements:
+         - Already need to have run forward pass with same `inputs` and `missing_mask`.
+         
+        Outputs:
+         - samples: tensor (num_features, batch_size):
+                 replaces the missing values in inputs sampled by pr(x_miss | x_not miss)
+        """
+        assert self.node_mars is not None and self.element_mars is not None, "Should run forward path first."
+
+        inputs = inputs.permute(1, 0)
+        missing_mask = missing_mask.permute(1, 0)
+
+        samples = torch.clone(inputs)
+        
+        self.node_flows = torch.zeros([self.num_nodes, self.node_mars.size(1)], device = self.device, dtype=torch.bool)
+        self.element_flows = torch.zeros([self.num_elements, self.node_mars.size(1)], device = self.device, dtype=torch.bool)
+        self.node_flows[-1,:] = 1.0
+
+        with torch.no_grad():
+            for layer_id in range(len(self.inner_layers) - 1, -1, -1):
+                ltype, layer = self.inner_layers[layer_id]
+
+                if ltype == "prod":
+                    # nothing special needed, same as backward
+                    layer.backward(self.node_flows, self.element_flows, skip_logsumexp=self.skip_logsumexp)
+
+                elif ltype == "sum":
+                    # recompute element_mars for previous prod layer
+                    self.inner_layers[layer_id-1][1].forward(self.node_mars, self.element_mars, skip_logsumexp = self.skip_logsumexp)
+                    layer.sample(self.node_flows, self.element_flows, self.node_mars, self.element_mars, self.params)
+                else:
+                    raise ValueError(f"Unknown layer type {ltype}.")
+                
+
+            for idx, layer in enumerate(self.input_layers):
+                layer.sample(samples, missing_mask, self.node_flows, self.element_flows, self.node_mars, self.element_mars)
+
+        return samples.permutes(1, 0)
+        
+
 
     def mini_batch_em(self, step_size: float, pseudocount: float = 0.0):
         for layer in self.input_layers:
@@ -291,6 +340,11 @@ class ProbCircuit(nn.Module):
     
         return pc
     
+    def save(self, filename):
+        self._init_pass_tensors_()
+        self._init_ad_tensors()
+        torch.save(self, filename)
+
 
     def to(self, device):
         super(ProbCircuit, self).to(device)
@@ -314,8 +368,9 @@ class ProbCircuit(nn.Module):
 
         return region_graph
 
-    def _init_layers(self, init_input_params: Optional[Sequence[torch.Tensor]] = None, init_inner_params: Optional[torch.Tensor] = None,
-                     max_num_groups: int = 1):
+    def _init_layers(self, init_input_params: Optional[Sequence[torch.Tensor]] = None, 
+                        init_inner_params: Optional[torch.Tensor] = None,
+                        max_num_groups: int = 1):
         depth2rnodes, num_layers = self._create_region_node_layers()
 
         if hasattr(self, "input_layers") or hasattr(self, "inner_layers"):

--- a/src/pyjuice/model/probcircuit.py
+++ b/src/pyjuice/model/probcircuit.py
@@ -287,7 +287,7 @@ class ProbCircuit(nn.Module):
             for idx, layer in enumerate(self.input_layers):
                 layer.sample(samples, missing_mask, self.node_flows)
 
-        return samples.permutes(1, 0)
+        return samples.permute(1, 0)
         
 
 


### PR DESCRIPTION


Similar to backward, but `node_flows` and `element_flows` are Boolean denoting whether than node is active for being sampled. 
- For prod nodes, sample is same as backwards (i.e. do sums which here becomes ORs since its booleans).
- For sum nodes, calculate $$\theta_c * p_c(x) $$ for all children of the sum node and sample proportional to that.
- For input nodes, sample input node but only the `node_flows` is 1 for that node, and only replace variable values if `missing_mask = True` for that (example, variable).

Remaining:
- [x] Validate the sum.sample
- [x] Sample for input layer, probably need a triton kernel that for each variable chooses the input node that has positive flow (for each variable exactly one input node for that variable should have flow 1), and then samples from that input distro and then replaces the original only when it was missing. Also there is a dimension for batch_id.

Training the circuit:

```
python examples/1_pc_training/train_mnist_hclt.py --mode train --output_dir examples/circuits
```

Run sampling (assumes already have circuits trained).
```
python examples/1_pc_training/train_mnist_hclt.py --mode sample --output_dir examples/circuits
```